### PR TITLE
Eighth pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
         echo 'Tag: ${{ steps.meta.outputs.tags }}'
         echo 'Label: ${{ steps.meta.labels.tags }}'
 
-    # - name: Build and push Docker image
-    #   uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-    #   with:
-    #     context: <go or python>
-    #     push: true
-    #     tags: ${{ steps.meta.outputs.tags }}
-    #     labels: ${{ steps.meta.outputs.labels }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        context: python
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6-alpine
+FROM python:3.9-alpine
 
 WORKDIR /app
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -9,8 +9,7 @@ RUN apk add --no-cache sqlite
 COPY . .
 
 RUN addgroup -S mercari && adduser -S trainee -G mercari
-RUN chown -R trainee:mercari /app/db
-RUN chown -R trainee:mercari /app/images
+RUN chown -R trainee:mercari /app
 
 USER trainee
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -10,6 +10,8 @@ COPY . .
 
 RUN addgroup -S mercari && adduser -S trainee -G mercari
 RUN chown -R trainee:mercari /app
+RUN chown -R trainee:mercari /app/db
+RUN chown -R trainee:mercari /app/images
 
 USER trainee
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.6-alpine
+FROM --platform=linux/arm64 python:3.9-slim
 
 WORKDIR /app
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 python:3.9-slim
+FROM python:3.9.6-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## What
<!--- Write the change being made with this pull request --->
2. GitHub Actionsを有効にする
3. アプリケーションをGitHub Actionsでビルドして、docker imageをregistryにupする
## Why
CI経由でdocker imageをpushし、ローカルでpullして実行した。
コンテナは動いているのに```curl: (56) Recv failure: Connection reset by peer```が出てしまうというエラーが発生していた。そこでDockerfileで利用するimageを3.9.6-alpineから3.9-alpineに変えると解決した。これは3.9.6-alpineに何かしらのバグや不安定要因があったからで、特定のバージョン (3.9.6-alpine) を指定するのではなく、3.9-alpine のように latest stable にしておくと、安定したバージョンが取得されるのではないかと考えた。

## 実行結果
```
docker pull ghcr.io/chihiro-sgw/mercari-build-training:eighth-pull-request
eighth-pull-request: Pulling from chihiro-sgw/mercari-build-training
9d50f2f29356: Download complete 
e1473d3b4546: Download complete 
a9948e85d045: Download complete 
5ef4a1a54640: Download complete 
03696e764faa: Download complete 
f18232174bc9: Download complete 
4f4fb700ef54: Already exists 
6efc7c91101b: Download complete 
3a1686d7ce15: Download complete 
35f1f8a1cc25: Download complete 
a8368e0f00ee: Download complete 
e323708b3d96: Download complete 
Digest: sha256:06d3511196b8f3a5554b3bba2e8f43bf2f7453633740b092f1059d5c142735cc
Status: Downloaded newer image for ghcr.io/chihiro-sgw/mercari-build-training:eighth-pull-request
ghcr.io/chihiro-sgw/mercari-build-training:eighth-pull-request

docker run --platform=linux/amd64 -d -p 9000:9000 ghcr.io/chihiro-sgw/mercari-build-training:eighth-pull-request
7bca6cae67f73674e54f01896393d9599d225fb4bc2c30533c10321796639297

curl -X POST --url 'http://localhost:9000/items' -F 'name=jacket' -F 'category=fashion' -F 'image=@Desktop/example.jpg'
{"message":"item received: jacket"}

curl -X GET --url 'http://127.0.0.1:9000/items'
{"items":[{"id":1,"name":"jacket","category":"fashion","image_name":"10cf1acfd6b38b00876ac82231e4699d5424a7e3570aaec4b1c45cea99f77334.jpg"}]}
```
## CHECKS :warning:

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
